### PR TITLE
Feat: 관리자 페이지 기능 개선 및 버그 수정

### DIFF
--- a/PopcornReview/src/main/java/com/service/popcornreview/controller/AdminController.java
+++ b/PopcornReview/src/main/java/com/service/popcornreview/controller/AdminController.java
@@ -152,23 +152,26 @@ public class AdminController {
 			
 	        return "redirect:/admin/list?section=movie";
 		} catch (Exception e) {
-			model.addAttribute("errorMessage","영화 삭제 실패 했습니다");
+			model.addAttribute("errorMessage","영화 삭제 실패 했습니다"+e.getMessage());
 			return "error"; 
 		}
 	}
 
 	// ADMIN-05: 리뷰 삭제 (POST) (변경 없음)
 	@PostMapping("/admin/review/delete")
-	public String doDeleteReviewAdmin(Integer reviewID, Model model, RedirectAttributes ra) {
-		try {
-			System.out.println("신고리뷰 삭제 진입");
-			reportService.deleteReported(reviewID);
-			ra.addFlashAttribute("message","리뷰가 삭제되었습니다.");
-			return "redirect:/admin/list?section=report"; 
-		} catch (Exception e) {
-			model.addAttribute("errorMessage","리뷰 삭제도중 오류가 발생했습니다."+e.getMessage());
-			return "error";
-		}
+	public String doDeleteReviewAdmin(Integer rrId, Model model, RedirectAttributes ra) {
+	    try {
+	        System.out.println("신고리뷰 및 원본리뷰 삭제 진입");
+	        
+	        // [수정] 새로 만든 서비스 메서드를 호출합니다.
+	        reportService.deleteReviewAndAssociatedReports(rrId);
+	        
+	        ra.addFlashAttribute("message", "리뷰가 성공적으로 삭제되었습니다.");
+	        return "redirect:/admin/list?section=report";
+	    } catch (Exception e) {
+	        model.addAttribute("errorMessage", "리뷰 삭제 중 오류가 발생했습니다: " + e.getMessage());
+	        return "error";
+	    }
 	}
 
 	// ADMIN-07: 공지사항 등록 (POST) (변경 없음)

--- a/PopcornReview/src/main/java/com/service/popcornreview/dao/MovieDao.java
+++ b/PopcornReview/src/main/java/com/service/popcornreview/dao/MovieDao.java
@@ -60,4 +60,9 @@ public class MovieDao {
 		System.out.println("MovieDao...deleteMovie");
 		return sqlSession.delete(NS + "deleteMovie", mId);
 	}
+	// [추가] 영화-배우 관계 삭제 메서드
+	public int deleteMovieActorRelations(String mId) {
+	    System.out.println("MovieDao...deleteMovieActorRelations");
+	    return sqlSession.delete(NS + "deleteMovieActorRelations", mId);
+	}
 }

--- a/PopcornReview/src/main/java/com/service/popcornreview/dao/ReportDao.java
+++ b/PopcornReview/src/main/java/com/service/popcornreview/dao/ReportDao.java
@@ -25,6 +25,11 @@ public class ReportDao {
 		System.out.println("ReportDao...deleteReported");
 		return sqlSession.delete(NS + "deleteReported", rrId);
 	}
+	// [추가] 리뷰 ID로 신고 내역을 삭제하는 메서드
+		public int deleteReportByReviewId(int rId) {
+			System.out.println("ReportDao...deleteReportByReviewId");
+			return sqlSession.delete(NS + "deleteReportByReviewId", rId);
+		}
 
 	public List<ReportedReview> getReported() {
 	    System.out.println("ReportDao...getReported");

--- a/PopcornReview/src/main/java/com/service/popcornreview/service/MovieService.java
+++ b/PopcornReview/src/main/java/com/service/popcornreview/service/MovieService.java
@@ -11,6 +11,7 @@ import java.util.Map;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.service.popcornreview.dao.MovieDao;
 import com.service.popcornreview.dto.AudienceStatsDto;
@@ -80,10 +81,16 @@ public class MovieService {
 		return movieDao.updateMovie(movie);
 	}
 
-	public int deleteMovie(String mId) {
-		System.out.println("MovieService...deleteMovie");
-		return movieDao.deleteMovie(mId);
-	}
+	 @Transactional
+	    public int deleteMovie(String mId) {
+	        System.out.println("MovieService...deleteMovie (and relations)");
+	        
+	        // 1. 자식 테이블(mov_act) 데이터 먼저 삭제
+	        movieDao.deleteMovieActorRelations(mId);
+	        
+	        // 2. 부모 테이블(movie) 데이터 삭제
+	        return movieDao.deleteMovie(mId);
+	    }
 	
 	
 	// --- MovieService 클래스 내부에 아래 메서드를 추가 ---

--- a/PopcornReview/src/main/java/com/service/popcornreview/service/ReportService.java
+++ b/PopcornReview/src/main/java/com/service/popcornreview/service/ReportService.java
@@ -4,8 +4,10 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.service.popcornreview.dao.ReportDao;
+import com.service.popcornreview.dao.ReviewDao;
 import com.service.popcornreview.vo.ReportedReview;
 
 @Service
@@ -13,6 +15,8 @@ public class ReportService {
 
 	@Autowired
 	private ReportDao reportDao;
+	@Autowired
+	private ReviewDao reviewDao;
 
 	public int insertReported(ReportedReview reportedReview) {
 		System.out.println("ReportService...insertReported");
@@ -22,6 +26,17 @@ public class ReportService {
 	public int deleteReported(int rrId) {
 		System.out.println("ReportService...deleteReported");
 		return reportDao.deleteReported(rrId);
+	}
+	
+	@Transactional
+	public void deleteReviewAndAssociatedReports(int rrId) {
+		System.out.println("ReportService...deleteReviewAndAssociatedReports");
+
+		// 1. 리뷰 ID에 연결된 모든 신고 내역 삭제
+		reportDao.deleteReportByReviewId(rrId);
+
+		// 2. 원본 리뷰 삭제 (ReviewDao에 리뷰를 삭제하는 메서드가 있다고 가정)
+		reviewDao.deleteReview(rrId);
 	}
 
 	public List<ReportedReview> getReported() {

--- a/PopcornReview/src/main/resources/mapper/movie-service-mapping.xml
+++ b/PopcornReview/src/main/resources/mapper/movie-service-mapping.xml
@@ -97,6 +97,8 @@
 	<delete id="deleteMovie" parameterType="string">
 		DELETE FROM movie WHERE m_id = #{value}
 	</delete>
-	
+	<delete id="deleteMovieActorRelations" parameterType="string">
+    DELETE FROM mov_act WHERE m_id = #{value}
+</delete>
 </mapper>
 

--- a/PopcornReview/src/main/resources/mapper/report-service-mapping.xml
+++ b/PopcornReview/src/main/resources/mapper/report-service-mapping.xml
@@ -33,6 +33,10 @@
 		DELETE FROM REPORTED_REVIEWS WHERE rr_id = #{value}
 	</delete>
 	
+	<delete id="deleteReportByReviewId" parameterType="int">
+    DELETE FROM REPORTED_REVIEWS WHERE r_id = #{value}
+	</delete>
+	
 	<select id="getReported" resultMap="ReportedReviewMap">
 		SELECT
 			rr.rr_id,

--- a/PopcornReview/src/main/webapp/WEB-INF/views/admin.jsp
+++ b/PopcornReview/src/main/webapp/WEB-INF/views/admin.jsp
@@ -52,6 +52,25 @@ body {
 	font-weight: bold;
 }
 
+.sidebar h2 a {
+	/* 기본 링크 스타일 초기화 */
+	color: inherit; /* 글자색은 부모(h2)의 흰색을 그대로 사용 */
+	text-decoration: none; /* 밑줄 제거 */
+	font-size: inherit; /* [추가] 부모(h2)의 글자 크기(24px)를 상속받음 */
+	/* 버튼 스타일에 덮어쓰기 (가장 중요) */
+	background-color: transparent; /* 배경색 없애기 */
+	padding: 0; /* 내부 여백 없애기 */
+	margin: 0; /* 외부 여백 없애기 */
+	display: inline; /* 너비를 글자에 맞게 자동 조절 */
+	width: auto; /* 너비 자동 설정 */
+	border-radius: 0; /* 둥근 모서리 없애기 */
+}
+
+/* Admin 제목에 마우스를 올려도 배경색이 변하지 않도록 설정 */
+.sidebar h2 a:hover {
+	background-color: transparent;
+}
+
 /* [수정 2] a 태그도 버튼처럼 보이도록 CSS 선택자를 추가합니다. */
 .sidebar button, .sidebar a {
 	background-color: #1F2937;
@@ -331,7 +350,9 @@ function openMovieEditModal(mId, mTitle, mSubtitle, mPlot, mRelease, mShowtime, 
 <body>
 	<div class="container">
 		<div class="sidebar">
-			<h2>Admin</h2>
+			<h2>
+				<a href="/">Admin</a>
+			</h2>
 			<a href="/admin/list?section=notice" id="btn-notice"
 				class="${activeSection == 'notice' ? 'active' : ''}">공지사항 관리</a> <a
 				href="/admin/list?section=movie" id="btn-movie"
@@ -344,7 +365,8 @@ function openMovieEditModal(mId, mTitle, mSubtitle, mPlot, mRelease, mShowtime, 
 			<div id="notice"
 				class="section ${activeSection == 'notice' ? 'active' : ''}">
 				<div class="title">공지사항 관리</div>
-				<button class="btn-top" onclick="openModal('modal-notice')">공지 등록</button>
+				<button class="btn-top" onclick="openModal('modal-notice')">공지
+					등록</button>
 				<div class="search-box">
 					<form method="get" action="/admin/notice/search">
 						<input type="text" name="keyword" placeholder="제목 검색" />
@@ -364,7 +386,8 @@ function openMovieEditModal(mId, mTitle, mSubtitle, mPlot, mRelease, mShowtime, 
 						<tbody>
 							<c:if test="${empty noticeList}">
 								<tr>
-									<td colspan="4" style="text-align: center;">등록된 공지사항이 없습니다.</td>
+									<td colspan="4" style="text-align: center;">등록된 공지사항이
+										없습니다.</td>
 								</tr>
 							</c:if>
 							<c:forEach var="notice" items="${noticeList}" varStatus="status">
@@ -393,7 +416,8 @@ function openMovieEditModal(mId, mTitle, mSubtitle, mPlot, mRelease, mShowtime, 
 			<div id="movie"
 				class="section ${activeSection == 'movie' ? 'active' : ''}">
 				<div class="title">영화 관리</div>
-				<button class="btn-top" onclick="openModal('modal-movie')">영화 등록</button>
+				<button class="btn-top" onclick="openModal('modal-movie')">영화
+					등록</button>
 				<div class="search-box">
 					<form method="get" action="/admin/movie/search">
 						<input type="text" name="keyword" placeholder="제목 검색" />
@@ -424,9 +448,8 @@ function openMovieEditModal(mId, mTitle, mSubtitle, mPlot, mRelease, mShowtime, 
 									<td>${movie.mSubtitle}</td>
 									<td>${movie.mRelease}</td>
 									<td>
-                                        <%-- ========================================================== --%>
-                                        <%-- [FINAL UPDATE] 수정 버튼 클릭 시 모든 영화 정보를 전달하도록 수정 --%>
-                                        <%-- ========================================================== --%>
+										<%-- ========================================================== --%>
+										<%-- [FINAL UPDATE] 수정 버튼 클릭 시 모든 영화 정보를 전달하도록 수정 --%> <%-- ========================================================== --%>
 										<button
 											onclick="openMovieEditModal(
 												'${movie.mId}',
@@ -496,7 +519,8 @@ function openMovieEditModal(mId, mTitle, mSubtitle, mPlot, mRelease, mShowtime, 
 									<td>
 										<form method="post" action="/admin/review/delete"
 											onsubmit="event.preventDefault(); confirmDelete(this);">
-											<input type="hidden" name="reviewID" value="${reportedReview.review.rId}">
+											<input type="hidden" name="rrId"
+												value="${reportedReview.review.rId}">
 											<button type="submit">삭제</button>
 										</form>
 									</td>
@@ -507,62 +531,72 @@ function openMovieEditModal(mId, mTitle, mSubtitle, mPlot, mRelease, mShowtime, 
 				</div>
 			</div>
 
-		<div class="modal" id="modal-notice">
-			<div class="modal-box">
-				<h3>공지사항</h3>
-				<form method="post" action="/admin/notice/add" data-guard="create">
-					<input type="hidden" name="noticeId" value="">
-					<input type="text" name="notice" placeholder="제목" required data-label="제목">
-					<textarea name="noticePlot" rows="6" placeholder="내용" required data-label="내용"></textarea>
-					<div class="button-group">
-						<button type="submit">등록</button>
-						<button type="button" onclick="closeModal('modal-notice')">취소</button>
-					</div>
-				</form>
+			<div class="modal" id="modal-notice">
+				<div class="modal-box">
+					<h3>공지사항</h3>
+					<form method="post" action="/admin/notice/add" data-guard="create">
+						<input type="hidden" name="noticeId" value=""> <input
+							type="text" name="notice" placeholder="제목" required
+							data-label="제목">
+						<textarea name="noticePlot" rows="6" placeholder="내용" required
+							data-label="내용"></textarea>
+						<div class="button-group">
+							<button type="submit">등록</button>
+							<button type="button" onclick="closeModal('modal-notice')">취소</button>
+						</div>
+					</form>
+				</div>
 			</div>
-		</div>
 
-		<div class="modal" id="modal-movie">
-			<div class="modal-box">
-				<h3>영화</h3>
-				<form method="post" action="/admin/movie/add" data-guard="create">
-					<input type="hidden" name="mId" value="">
-                    <input type="text" name="mTitle" placeholder="제목" required data-label="제목">
-                    <input type="text" name="mSubtitle" placeholder="소제목" data-label="소제목">
-					<textarea name="mPlot" rows="4" placeholder="내용" data-label="내용"></textarea>
-					<input type="date" name="mRelease" required data-label="개봉일">
-					<input type="text" name="mShowtime" placeholder="상영시간(분)" data-label="상영시간">
-                    <input type="text" name="mCategories" placeholder="장르" required data-label="장르">
-					<input type="text" name="mDirector" placeholder="감독" required data-label="감독">
-					<input type="text" name="actors" placeholder="배우 (쉼표로 구분)" data-label="배우">
-					<input type="text" name="mScreeningType" placeholder="상영 타입" data-label="상영 타입">
-                    <input type="text" name="mMovieTheater" placeholder="영화관" data-label="영화관">
-                    <input type="text" name="mUrlImage" placeholder="사진 URL" data-label="사진 URL">
-                    <input type="text" name="mUrlMovie" placeholder="영상 URL" data-label="영상 URL">
-					<div class="button-group">
-						<button type="submit">등록</button>
-						<button type="button" onclick="closeModal('modal-movie')">취소</button>
-					</div>
-				</form>
+			<div class="modal" id="modal-movie">
+				<div class="modal-box">
+					<h3>영화</h3>
+					<form method="post" action="/admin/movie/add" data-guard="create">
+						<input type="hidden" name="mId" value=""> <input
+							type="text" name="mTitle" placeholder="제목" required
+							data-label="제목"> <input type="text" name="mSubtitle"
+							placeholder="소제목" data-label="소제목">
+						<textarea name="mPlot" rows="4" placeholder="내용" data-label="내용"></textarea>
+						<input type="date" name="mRelease" required data-label="개봉일">
+						<input type="text" name="mShowtime" placeholder="상영시간(분)"
+							data-label="상영시간"> <input type="text" name="mCategories"
+							placeholder="장르" required data-label="장르"> <input
+							type="text" name="mDirector" placeholder="감독" required
+							data-label="감독"> <input type="text" name="actors"
+							placeholder="배우 (쉼표로 구분)" data-label="배우"> <input
+							type="text" name="mScreeningType" placeholder="상영 타입"
+							data-label="상영 타입"> <input type="text"
+							name="mMovieTheater" placeholder="영화관" data-label="영화관">
+						<input type="text" name="mUrlImage" placeholder="사진 URL"
+							data-label="사진 URL"> <input type="text" name="mUrlMovie"
+							placeholder="영상 URL" data-label="영상 URL">
+						<div class="button-group">
+							<button type="submit">등록</button>
+							<button type="button" onclick="closeModal('modal-movie')">취소</button>
+						</div>
+					</form>
+				</div>
 			</div>
-		</div>
 
-		<div class="modal" id="modal-actor">
-			<div class="modal-box">
-				<h3>배우 등록</h3>
-				<form method="post" action="/admin/actor/add" data-guard="create">
-					<input type="text" name="aName" placeholder="이름" required data-label="이름">
-					<textarea name="aPlot" rows="4" placeholder="소개" required data-label="소개"></textarea>
-					<input type="text" name="aUrlImage" placeholder="사진 URL" required data-label="사진 URL">
-					<div class="button-group">
-						<button type="submit">등록</button>
-						<button type="button" onclick="closeModal('modal-actor')">취소</button>
-					</div>
-				</form>
+			<div class="modal" id="modal-actor">
+				<div class="modal-box">
+					<h3>배우 등록</h3>
+					<form method="post" action="/admin/actor/add" data-guard="create">
+						<input type="text" name="aName" placeholder="이름" required
+							data-label="이름">
+						<textarea name="aPlot" rows="4" placeholder="소개" required
+							data-label="소개"></textarea>
+						<input type="text" name="aUrlImage" placeholder="사진 URL" required
+							data-label="사진 URL">
+						<div class="button-group">
+							<button type="submit">등록</button>
+							<button type="button" onclick="closeModal('modal-actor')">취소</button>
+						</div>
+					</form>
+				</div>
 			</div>
-		</div>
 
-		<script>
+			<script>
         (function(){
             document.querySelectorAll('form[data-guard]').forEach(function(form){
             var mode = (form.getAttribute('data-guard') || 'create').toLowerCase();

--- a/PopcornReview/src/main/webapp/WEB-INF/views/include/header.jsp
+++ b/PopcornReview/src/main/webapp/WEB-INF/views/include/header.jsp
@@ -40,26 +40,37 @@
 			</div>
             
             <div class="header-buttons">
+    <c:choose>
+        <%-- 1. 로그인하지 않았을 때 --%>
+        <c:when test="${empty sessionScope.loginUser}">
+            <button class="btn-login">로그인</button>
+        </c:when>
+
+        <%-- 2. 로그인했을 때 --%>
+        <c:otherwise>
+            <%-- 사용자 이름이 표시되는 버튼 --%>
+            <button type="button" class="btn-user" id="userMenuButton">
+                ${sessionScope.loginUser.name} 님
+                <span>▼</span>
+            </button>
+            
+            <%-- 드롭다운 메뉴 --%>
+            <div class="dropdown-menu" id="userDropdownMenu">
+                <%-- 2-1. 드롭다운 메뉴 안에서 관리자인지 일반 사용자인지 다시 확인 --%>
                 <c:choose>
-                    <c:when test="${empty sessionScope.loginUser}">
-                        <button class="btn-login">로그인</button>
+                    <c:when test="${sessionScope.loginUser.id == 'admin'}">
+                        <a href="/admin">관리자 페이지</a>
                     </c:when>
-                    
                     <c:otherwise>
-                        <%-- 버튼은 이제 드롭다운을 여는 역할만 합니다. --%>
-                        <button type="button" class="btn-user" id="userMenuButton">
-                            ${sessionScope.loginUser.name} 님
-                            <span>▼</span> <%-- 아래 화살표 아이콘 --%>
-                        </button>
-                        
-                        <%-- 실제 링크가 담긴 드롭다운 메뉴 --%>
-                        <div class="dropdown-menu" id="userDropdownMenu">
-                            <a href="/user/mypage">마이페이지</a>
-                            <a href="/user/logout">로그아웃</a>
-                        </div>
+                        <a href="/user/mypage">마이페이지</a>
                     </c:otherwise>
                 </c:choose>
+                <%-- 로그아웃 링크는 공통으로 표시 --%>
+                <a href="/user/logout">로그아웃</a>
             </div>
+        </c:otherwise>
+    </c:choose>
+</div>
         </div>
     </header>
 


### PR DESCRIPTION
 1. 관리자 페이지 기능 개선

- 공통 헤더: 관리자 계정('admin')으로 로그인 시, '마이페이지' 버튼이 '관리자 페이지'로 표시되도록 수정
- 사이드바 UI: 'Admin' 제목을 클릭하면 홈페이지로 이동하도록 링크를 추가하고, 기존 디자인을 해치지 않도록 스타일을 적용

2. 주요 버그 수정

- 영화 삭제 오류 해결: 영화 삭제 시, 배우 출연 정보(mov_act)가 먼저 삭제되지 않아 발생하던 외래 키 제약 조건 오류를 해결
  - MovieService의 삭제 로직을 @Transactional로 처리하여, 연결된 배우 정보를 먼저 삭제한 후 영화가 삭제되도록 순서를 변경

- 리뷰 삭제 오류 해결: 신고된 리뷰 삭제 시, 신고 내역(reported_reviews)이 먼저 삭제되지 않아 발생하던 외래 키 제약 조건 오류를 해결했습니다.
  - ReportService에 관련 신고 내역과 원본 리뷰를 함께 삭제하는 트랜잭션 메서드를 추가하여 로직을 수정했습니다.

3. 기타 코드 수정
- MyBatis 매퍼 수정: `report-service-mapping.xml` 파일에 있던 잘못된 XML 주석 구문을 수정
- Service 로직 수정: `ReportService`에서 `ReviewDao`를 `ReportDao`로 잘못 주입하던 문제를 바로잡음